### PR TITLE
#8 Make SchedulerClient as an interface and create a SchedulerRestClient type to implement it

### DIFF
--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -27,7 +27,7 @@ var loggingClient logger.LoggingClient
 func main() {
 	start := time.Now()
 	var (
-		useConsul = flag.String("consul", "", "Should the service use consul?")
+		useConsul  = flag.String("consul", "", "Should the service use consul?")
 		useProfile = flag.String("profile", "default", "Specify a profile other than default.")
 	)
 	flag.Parse()
@@ -60,11 +60,7 @@ func main() {
 	loggingClient.Info(consulMsg)
 	loggingClient.Info(fmt.Sprintf("starting %s %s ", scheduler.SupportSchedulerServiceName, edgex.Version))
 
-	var schedulerClient = sc.SchedulerClient{
-		SchedulerServiceHost: configuration.ServiceHost,
-		SchedulerServicePort: 48081,
-		OwningService: scheduler.SupportSchedulerServiceName,
-	}
+	var schedulerClient = sc.NewSchedulerRestClient(configuration.ServiceHost, 48081, scheduler.SupportSchedulerServiceName)
 
 	scheduler.Init(*configuration, loggingClient, schedulerClient)
 

--- a/support/scheduler-client/client.go
+++ b/support/scheduler-client/client.go
@@ -28,18 +28,38 @@ const (
 	UrlPattern           = "http://%s:%d%s"
 )
 
+type SchedulerClient interface {
+	QuerySchedule(id string) (models.Schedule, error)
+	QueryScheduleWithName(scheduleName string) (models.Schedule, error)
+	AddSchedule(schedule models.Schedule) error
+	UpdateSchedule(schedule models.Schedule) error
+	RemoveSchedule(id string) error
+	QueryScheduleEvent(id string) (models.ScheduleEvent, error)
+	AddScheduleEvent(scheduleEvent models.ScheduleEvent) error
+	UpdateScheduleEvent(scheduleEvent models.ScheduleEvent) error
+	RemoveScheduleEvent(id string) error
+}
+
 // Struct to represent the scheduler client
-type SchedulerClient struct {
+type SchedulerRestClient struct {
 	SchedulerServiceHost string
 	SchedulerServicePort int
 	OwningService        string
 }
 
+func NewSchedulerRestClient(ssh string, ssp int, os string) SchedulerClient {
+	return &SchedulerRestClient{
+		SchedulerServiceHost: ssh,
+		SchedulerServicePort: ssp,
+		OwningService:        os,
+	}
+}
+
 // Function to get a schedule from the remote scheduler server
-func (schedulerClient SchedulerClient) QuerySchedule(id string) (models.Schedule, error) {
+func (src SchedulerRestClient) QuerySchedule(id string) (models.Schedule, error) {
 	client := &http.Client{}
 
-	remoteScheduleUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleApiPath)
+	remoteScheduleUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleApiPath)
 	remoteScheduleUrl = remoteScheduleUrl + "/" + id
 
 	jsonBytes, err := doGet(remoteScheduleUrl, client)
@@ -57,10 +77,10 @@ func (schedulerClient SchedulerClient) QuerySchedule(id string) (models.Schedule
 }
 
 // Function to get a schedule with schedule name from the remote scheduler server
-func (schedulerClient SchedulerClient) QueryScheduleWithName(scheduleName string) (models.Schedule, error) {
+func (src SchedulerRestClient) QueryScheduleWithName(scheduleName string) (models.Schedule, error) {
 	client := &http.Client{}
 
-	remoteScheduleUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleApiPath)
+	remoteScheduleUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleApiPath)
 	remoteScheduleUrl = remoteScheduleUrl + "/name/" + scheduleName
 
 	jsonBytes, err := doGet(remoteScheduleUrl, client)
@@ -78,7 +98,7 @@ func (schedulerClient SchedulerClient) QueryScheduleWithName(scheduleName string
 }
 
 // Function to send a schedule to the remote scheduler server
-func (schedulerClient SchedulerClient) AddSchedule(schedule models.Schedule) error {
+func (src SchedulerRestClient) AddSchedule(schedule models.Schedule) error {
 	client := &http.Client{}
 
 	requestBody, err := schedule.MarshalJSON()
@@ -86,13 +106,13 @@ func (schedulerClient SchedulerClient) AddSchedule(schedule models.Schedule) err
 		return err
 	}
 
-	remoteScheduleUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleApiPath)
+	remoteScheduleUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleApiPath)
 
 	return doPost(remoteScheduleUrl, bytes.NewBuffer(requestBody), client)
 }
 
 // Function to update a schedule to the remote scheduler server
-func (schedulerClient SchedulerClient) UpdateSchedule(schedule models.Schedule) error {
+func (src SchedulerRestClient) UpdateSchedule(schedule models.Schedule) error {
 	client := &http.Client{}
 
 	requestBody, err := schedule.MarshalJSON()
@@ -100,26 +120,26 @@ func (schedulerClient SchedulerClient) UpdateSchedule(schedule models.Schedule) 
 		return err
 	}
 
-	remoteScheduleUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleApiPath)
+	remoteScheduleUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleApiPath)
 
 	return doPut(remoteScheduleUrl, bytes.NewBuffer(requestBody), client)
 }
 
 // Function to remove a schedule to the remote scheduler server
-func (schedulerClient SchedulerClient) RemoveSchedule(id string) error {
+func (src SchedulerRestClient) RemoveSchedule(id string) error {
 	client := &http.Client{}
 
-	remoteScheduleUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleApiPath)
+	remoteScheduleUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleApiPath)
 	remoteScheduleUrl = remoteScheduleUrl + "/" + id
 
 	return doDelete(remoteScheduleUrl, client)
 }
 
 // Function to get a schedule event from the remote scheduler server
-func (schedulerClient SchedulerClient) QueryScheduleEvent(id string) (models.ScheduleEvent, error) {
+func (src SchedulerRestClient) QueryScheduleEvent(id string) (models.ScheduleEvent, error) {
 	client := &http.Client{}
 
-	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleEventApiPath)
+	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleEventApiPath)
 	remoteScheduleEventUrl = remoteScheduleEventUrl + "/" + id
 
 	jsonBytes, err := doGet(remoteScheduleEventUrl, client)
@@ -137,7 +157,7 @@ func (schedulerClient SchedulerClient) QueryScheduleEvent(id string) (models.Sch
 }
 
 // Function to send a schedule event to the remote scheduler server
-func (schedulerClient SchedulerClient) AddScheduleEvent(scheduleEvent models.ScheduleEvent) error {
+func (src SchedulerRestClient) AddScheduleEvent(scheduleEvent models.ScheduleEvent) error {
 	client := &http.Client{}
 
 	requestBody, err := scheduleEvent.MarshalJSON()
@@ -145,13 +165,13 @@ func (schedulerClient SchedulerClient) AddScheduleEvent(scheduleEvent models.Sch
 		return err
 	}
 
-	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleEventApiPath)
+	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleEventApiPath)
 
 	return doPost(remoteScheduleEventUrl, bytes.NewBuffer(requestBody), client)
 }
 
 // Function to update a schedule event to the remote scheduler server
-func (schedulerClient SchedulerClient) UpdateScheduleEvent(scheduleEvent models.ScheduleEvent) error {
+func (src SchedulerRestClient) UpdateScheduleEvent(scheduleEvent models.ScheduleEvent) error {
 	client := &http.Client{}
 
 	requestBody, err := scheduleEvent.MarshalJSON()
@@ -159,16 +179,16 @@ func (schedulerClient SchedulerClient) UpdateScheduleEvent(scheduleEvent models.
 		return err
 	}
 
-	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleEventApiPath)
+	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleEventApiPath)
 
 	return doPut(remoteScheduleEventUrl, bytes.NewBuffer(requestBody), client)
 }
 
 // Function to remove a schedule event to the remote scheduler server
-func (schedulerClient SchedulerClient) RemoveScheduleEvent(id string) error {
+func (src SchedulerRestClient) RemoveScheduleEvent(id string) error {
 	client := &http.Client{}
 
-	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, schedulerClient.SchedulerServiceHost, schedulerClient.SchedulerServicePort, ScheduleEventApiPath)
+	remoteScheduleEventUrl := fmt.Sprintf(UrlPattern, src.SchedulerServiceHost, src.SchedulerServicePort, ScheduleEventApiPath)
 	remoteScheduleEventUrl = remoteScheduleEventUrl + "/" + id
 
 	return doDelete(remoteScheduleEventUrl, client)

--- a/support/scheduler-client/client_test.go
+++ b/support/scheduler-client/client_test.go
@@ -106,7 +106,7 @@ func TestAddSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -180,7 +180,7 @@ func TestQuerySchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -269,7 +269,7 @@ func TestQueryScheduleWithName(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -363,7 +363,7 @@ func TestUpdateSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -416,7 +416,7 @@ func TestRemoveSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -486,7 +486,7 @@ func TestAddScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -561,7 +561,7 @@ func TestQueryScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -656,7 +656,7 @@ func TestUpdateScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",
@@ -711,7 +711,7 @@ func TestRemoveScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
+	scheduleClient := SchedulerRestClient{
 		SchedulerServiceHost: h[0],
 		SchedulerServicePort: intPort,
 		OwningService:        "notifications",

--- a/support/scheduler/schedule_test.go
+++ b/support/scheduler/schedule_test.go
@@ -60,10 +60,8 @@ func mockInit(host string, port int) {
 	var loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, "")
 	Init(ConfigurationStruct{
 		ScheduleInterval: 500,
-	}, loggingClient, scheduler.SchedulerClient{
-		SchedulerServiceHost: host,
-		SchedulerServicePort: port,
-	})
+	}, loggingClient,
+		scheduler.NewSchedulerRestClient(host, port, "scheduler"))
 	StartTicker()
 }
 


### PR DESCRIPTION
Signed-off-by: yanghua <yanghua1127@gmail.com>

@tsconn23 this PR just make a partial refactor, because it depends on PR #7 , there exists a `providers.go` file.

I will do a complete refactor after you merge these two PRs.